### PR TITLE
Handle email verification for pods without notification support

### DIFF
--- a/src/controllers/integration.ts
+++ b/src/controllers/integration.ts
@@ -47,7 +47,7 @@ export const initializeIntegration: Middleware = async ctx => {
   await sendMail({
     from: config.emailSender,
     to: email,
-    subject: 'TODO',
+    subject: 'Verify your email for sleepy.bike notifications',
     html: `Please verify your email <a href="${emailVerificationLink}">click here</a>`,
     text: `Please verify your email ${emailVerificationLink}`,
   })
@@ -103,12 +103,18 @@ export const finishIntegration: Middleware = async ctx => {
   // save the integration to database
   await Integration.create(integrationData)
 
-  // subscribe to the inbox' webhook notifications
-  await subscribeForNotifications(integrationData.inbox)
-
-  ctx.response.body =
-    'Email notifications have been successfully integrated to your inbox'
-  ctx.response.status = 200
+  try {
+    // subscribe to the inbox' webhook notifications
+    await subscribeForNotifications(integrationData.inbox)
+    ctx.response.body =
+      'Email notifications have been successfully integrated to your inbox'
+  } catch (e) {
+    ctx.response.body =
+      "Email was successfully verified, but notifications won't work, yet. It looks like your Solid Pod doesn't support notifications. We'll implement a workaround in the future.\nError: " +
+      (e as Error).message
+  } finally {
+    ctx.response.status = 200
+  }
 }
 
 type Fetch = typeof fetch

--- a/src/test/css-config-no-notifications.json
+++ b/src/test/css-config-no-notifications.json
@@ -1,0 +1,41 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^6.0.0/components/context.jsonld",
+  "import": [
+    "css:config/app/main/default.json",
+    "css:config/app/init/initialize-prefilled-root.json",
+    "css:config/app/setup/optional.json",
+    "css:config/app/variables/default.json",
+    "css:config/http/handler/default.json",
+    "css:config/http/middleware/default.json",
+    "css:config/http/notifications/disabled.json",
+    "css:config/http/server-factory/http.json",
+    "css:config/http/static/default.json",
+    "css:config/identity/access/public.json",
+    "css:config/identity/email/default.json",
+    "css:config/identity/handler/default.json",
+    "css:config/identity/ownership/token.json",
+    "css:config/identity/pod/static.json",
+    "css:config/identity/registration/enabled.json",
+    "css:config/ldp/authentication/dpop-bearer.json",
+    "css:config/ldp/authorization/webacl.json",
+    "css:config/ldp/handler/default.json",
+    "css:config/ldp/metadata-parser/default.json",
+    "css:config/ldp/metadata-writer/default.json",
+    "css:config/ldp/modes/default.json",
+    "css:config/storage/backend/memory.json",
+    "css:config/storage/key-value/resource-store.json",
+    "css:config/storage/middleware/default.json",
+    "css:config/util/auxiliary/acl.json",
+    "css:config/util/identifiers/suffix.json",
+    "css:config/util/index/default.json",
+    "css:config/util/logging/winston.json",
+    "css:config/util/representation-conversion/default.json",
+    "css:config/util/resource-locker/memory.json",
+    "css:config/util/variables/default.json"
+  ],
+  "@graph": [
+    {
+      "comment": "A Solid server that stores its resources in memory and uses WAC for authorization."
+    }
+  ]
+}


### PR DESCRIPTION
When notification subscription fails, we verify the email, but we inform user that email notifications won't arrive.