### PR TITLE
Specify whether server runs behind reverse proxy

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,13 @@
 # port on which the service will run
 PORT=3005
+
 # server base url, e.g. to construct correct email verification link
 # this is the base url that end users see
 BASE_URL=http://localhost:3005
+
+# set to true if server runs behind reverse proxy (e.g. nginx)
+BEHIND_PROXY=
+
 # mailer Solid identity
 # mailer needs Solid identity to authenticate with, it's set up to use Community Solid Server as identity provider
 MAILER_IDENTITY_EMAIL=bot@example

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import Router from '@koa/router'
 import Koa from 'koa'
 import helmet from 'koa-helmet'
 import serve from 'koa-static'
+import { isBehindProxy } from './config'
 import {
   checkVerificationLink,
   finishIntegration,
@@ -15,6 +16,7 @@ import { solidAuth } from './middlewares/solidAuth'
 import { validateBody } from './middlewares/validate'
 
 const app = new Koa()
+app.proxy = isBehindProxy
 const router = new Router()
 
 router

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -52,3 +52,5 @@ export const database: Options = {
   host: process.env.DB_HOST || undefined,
   port: process.env.DB_PORT ? +process.env.DB_PORT : undefined,
 }
+
+export const isBehindProxy = stringToBoolean(process.env.BEHIND_PROXY)


### PR DESCRIPTION
We introduce environment variable `BEHIND_PROXY`, which should be set to true when the application runs behind reverse proxy. This way protocol gets correctly passed from e.g. nginx to koa via X-Forwarded-Proto header
https://github.com/koajs/koa/blob/dbf4b8f41286befd53dfd802740f2021441435bf/docs/api/request.md#requestprotocol